### PR TITLE
ASAP-456 비회원 이미지 업로드 로직 추가 및 테스트 보완

### DIFF
--- a/Application-Module/src/main/kotlin/com/asap/application/image/port/in/UploadImageUsecase.kt
+++ b/Application-Module/src/main/kotlin/com/asap/application/image/port/in/UploadImageUsecase.kt
@@ -9,7 +9,7 @@ interface UploadImageUsecase {
 
     data class Command(
         val image: FileMetaData,
-        val userId: String
+        val userId: String? = null
     )
 
     data class Response(

--- a/Application-Module/src/main/kotlin/com/asap/application/image/service/ImageCommandService.kt
+++ b/Application-Module/src/main/kotlin/com/asap/application/image/service/ImageCommandService.kt
@@ -10,19 +10,32 @@ import org.springframework.stereotype.Service
 @Service
 class ImageCommandService(
     private val imageManagementPort: ImageManagementPort,
-    private val userManagementPort: UserManagementPort
+    private val userManagementPort: UserManagementPort,
 ) : UploadImageUsecase {
-    override fun upload(command: UploadImageUsecase.Command): UploadImageUsecase.Response {
-        val user = userManagementPort.getUserNotNull(DomainId(command.userId))
+    companion object {
+        private const val ANONYMOUS_OWNER_ID = "anonymous"
+    }
 
-        val uploadedImage = imageManagementPort.save(
-            ImageMetadata(
-                owner = user.id.value,
-                fileMetaData = command.image
+    override fun upload(command: UploadImageUsecase.Command): UploadImageUsecase.Response {
+        val owner =
+            when {
+                command.userId != null -> {
+                    val user = userManagementPort.getUserNotNull(DomainId(command.userId))
+                    user.id.value
+                }
+
+                else -> ANONYMOUS_OWNER_ID
+            }
+
+        val uploadedImage =
+            imageManagementPort.save(
+                ImageMetadata(
+                    owner = owner,
+                    fileMetaData = command.image,
+                ),
             )
-        )
         return UploadImageUsecase.Response(
-            imageUrl = uploadedImage.imageUrl
+            imageUrl = uploadedImage.imageUrl,
         )
     }
 }

--- a/Application-Module/src/main/kotlin/com/asap/application/image/service/ImageCommandService.kt
+++ b/Application-Module/src/main/kotlin/com/asap/application/image/service/ImageCommandService.kt
@@ -12,25 +12,13 @@ class ImageCommandService(
     private val imageManagementPort: ImageManagementPort,
     private val userManagementPort: UserManagementPort,
 ) : UploadImageUsecase {
-    companion object {
-        private const val ANONYMOUS_OWNER_ID = "anonymous"
-    }
-
     override fun upload(command: UploadImageUsecase.Command): UploadImageUsecase.Response {
-        val owner =
-            when {
-                command.userId != null -> {
-                    val user = userManagementPort.getUserNotNull(DomainId(command.userId))
-                    user.id.value
-                }
-
-                else -> ANONYMOUS_OWNER_ID
-            }
+        val user = command.userId?.let { userManagementPort.getUserNotNull(DomainId(it)) }
 
         val uploadedImage =
             imageManagementPort.save(
                 ImageMetadata(
-                    owner = owner,
+                    owner = user?.id?.value,
                     fileMetaData = command.image,
                 ),
             )

--- a/Application-Module/src/main/kotlin/com/asap/application/image/vo/ImageMetadata.kt
+++ b/Application-Module/src/main/kotlin/com/asap/application/image/vo/ImageMetadata.kt
@@ -3,7 +3,6 @@ package com.asap.application.image.vo
 import com.asap.common.file.FileMetaData
 
 data class ImageMetadata(
-    val owner: String,
-    val fileMetaData: FileMetaData
-) {
-}
+    val owner: String?,
+    val fileMetaData: FileMetaData,
+)

--- a/Application-Module/src/test/kotlin/com/asap/application/image/service/ImageCommandServiceTest.kt
+++ b/Application-Module/src/test/kotlin/com/asap/application/image/service/ImageCommandServiceTest.kt
@@ -2,22 +2,21 @@ package com.asap.application.image.service
 
 import com.asap.application.image.port.`in`.UploadImageUsecase
 import com.asap.application.image.port.out.ImageManagementPort
-import com.asap.application.image.vo.ImageMetadata
 import com.asap.application.image.vo.UploadedImage
 import com.asap.application.user.port.out.UserManagementPort
 import com.asap.common.file.FileMetaData
 import com.asap.domain.UserFixture
+import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
-import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
 import io.mockk.verify
 import java.io.InputStream
 
 class ImageCommandServiceTest :
     BehaviorSpec({
+        isolationMode = IsolationMode.InstancePerLeaf
 
         val mockImageManagementPort = mockk<ImageManagementPort>(relaxed = true)
         val mockUserManagementPort = mockk<UserManagementPort>(relaxed = true)
@@ -27,38 +26,6 @@ class ImageCommandServiceTest :
                 mockImageManagementPort,
                 mockUserManagementPort,
             )
-
-        given("익명 사용자의 이미지 업로드 요청이 들어올 때") {
-            val command =
-                UploadImageUsecase.Command(
-                    userId = null,
-                    image =
-                        FileMetaData(
-                            name = "name",
-                            contentType = "contentType",
-                            size = 1L,
-                            inputStream = InputStream.nullInputStream(),
-                        ),
-                )
-            val imageMetadataSlot = slot<ImageMetadata>()
-            every {
-                mockImageManagementPort.save(capture(imageMetadataSlot))
-            } returns
-                UploadedImage(
-                    imageUrl = "anonymousImageUrl",
-                )
-            `when`("이미지 업로드 요청을 처리하면") {
-                val response = imageCommandService.upload(command)
-                then("이미지가 저장되어야 한다") {
-                    response.imageUrl shouldNotBeNull {
-                        this.isNotBlank()
-                        this.isNotEmpty()
-                    }
-                    verify { mockImageManagementPort.save(any()) }
-                    imageMetadataSlot.captured.owner shouldBe "anonymous"
-                }
-            }
-        }
 
         given("이미지 업로드 요청이 들어올 때") {
             val mockUser = UserFixture.createUser()
@@ -84,6 +51,38 @@ class ImageCommandServiceTest :
                 )
             `when`("이미지 업로드 요청을 처리하면") {
                 val response = imageCommandService.upload(command)
+                then("이미지가 저장되어야 한다") {
+                    response.imageUrl shouldNotBeNull {
+                        this.isNotBlank()
+                        this.isNotEmpty()
+                    }
+                }
+            }
+        }
+
+        given("userId가 null인 이미지 업로드 요청이 들어올 때") {
+            val command =
+                UploadImageUsecase.Command(
+                    userId = null,
+                    image =
+                        FileMetaData(
+                            name = "name",
+                            contentType = "contentType",
+                            size = 1L,
+                            inputStream = InputStream.nullInputStream(),
+                        ),
+                )
+            every {
+                mockImageManagementPort.save(any())
+            } returns
+                UploadedImage(
+                    imageUrl = "imageUrl",
+                )
+            `when`("이미지 업로드 요청을 처리하면") {
+                val response = imageCommandService.upload(command)
+                then("getUserNotNull 메서드가 호출되지 않아야 한다") {
+                    verify(exactly = 0) { mockUserManagementPort.getUserNotNull(any()) }
+                }
                 then("이미지가 저장되어야 한다") {
                     response.imageUrl shouldNotBeNull {
                         this.isNotBlank()

--- a/Application-Module/src/test/kotlin/com/asap/application/image/service/ImageCommandServiceTest.kt
+++ b/Application-Module/src/test/kotlin/com/asap/application/image/service/ImageCommandServiceTest.kt
@@ -2,14 +2,18 @@ package com.asap.application.image.service
 
 import com.asap.application.image.port.`in`.UploadImageUsecase
 import com.asap.application.image.port.out.ImageManagementPort
+import com.asap.application.image.vo.ImageMetadata
 import com.asap.application.image.vo.UploadedImage
 import com.asap.application.user.port.out.UserManagementPort
 import com.asap.common.file.FileMetaData
 import com.asap.domain.UserFixture
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
 import java.io.InputStream
 
 class ImageCommandServiceTest :
@@ -23,6 +27,38 @@ class ImageCommandServiceTest :
                 mockImageManagementPort,
                 mockUserManagementPort,
             )
+
+        given("익명 사용자의 이미지 업로드 요청이 들어올 때") {
+            val command =
+                UploadImageUsecase.Command(
+                    userId = null,
+                    image =
+                        FileMetaData(
+                            name = "name",
+                            contentType = "contentType",
+                            size = 1L,
+                            inputStream = InputStream.nullInputStream(),
+                        ),
+                )
+            val imageMetadataSlot = slot<ImageMetadata>()
+            every {
+                mockImageManagementPort.save(capture(imageMetadataSlot))
+            } returns
+                UploadedImage(
+                    imageUrl = "anonymousImageUrl",
+                )
+            `when`("이미지 업로드 요청을 처리하면") {
+                val response = imageCommandService.upload(command)
+                then("이미지가 저장되어야 한다") {
+                    response.imageUrl shouldNotBeNull {
+                        this.isNotBlank()
+                        this.isNotEmpty()
+                    }
+                    verify { mockImageManagementPort.save(any()) }
+                    imageMetadataSlot.captured.owner shouldBe "anonymous"
+                }
+            }
+        }
 
         given("이미지 업로드 요청이 들어올 때") {
             val mockUser = UserFixture.createUser()

--- a/Bootstrap-Module/src/main/kotlin/com/asap/bootstrap/common/config/WebConfig.kt
+++ b/Bootstrap-Module/src/main/kotlin/com/asap/bootstrap/common/config/WebConfig.kt
@@ -8,11 +8,11 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
 class WebConfig(
-    private val accessUserArgumentResolver: AccessUserArgumentResolver
+    private val accessUserArgumentResolver: AccessUserArgumentResolver,
 ) : WebMvcConfigurer {
-
     override fun addCorsMappings(registry: CorsRegistry) {
-        registry.addMapping("/**")
+        registry
+            .addMapping("/**")
             .allowedOrigins("*")
             .allowedMethods("GET", "POST", "PUT", "DELETE")
             .allowedHeaders("*")

--- a/Bootstrap-Module/src/main/kotlin/com/asap/bootstrap/common/security/annotation/AccessUserArgumentResolver.kt
+++ b/Bootstrap-Module/src/main/kotlin/com/asap/bootstrap/common/security/annotation/AccessUserArgumentResolver.kt
@@ -10,20 +10,17 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.method.support.ModelAndViewContainer
 
 @Component
-class AccessUserArgumentResolver: HandlerMethodArgumentResolver {
-
-    override fun supportsParameter(parameter: MethodParameter): Boolean {
-        return parameter.hasParameterAnnotation(AccessUser::class.java)
-    }
+class AccessUserArgumentResolver : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean = parameter.hasParameterAnnotation(AccessUser::class.java)
 
     override fun resolveArgument(
         parameter: MethodParameter,
         mavContainer: ModelAndViewContainer?,
         webRequest: NativeWebRequest,
-        binderFactory: WebDataBinderFactory?
+        binderFactory: WebDataBinderFactory?,
     ): Any? {
-        val userAuthentication = SecurityContextHolder.getContext().getAuthentication() as UserAuthentication
-        val userId = userAuthentication.getDetails()
-        return userId
+        val authentication = SecurityContextHolder.getContext()?.getAuthentication()
+        val userAuthentication = authentication as? UserAuthentication
+        return userAuthentication?.getDetails()
     }
 }

--- a/Bootstrap-Module/src/main/kotlin/com/asap/bootstrap/web/image/api/ImageApi.kt
+++ b/Bootstrap-Module/src/main/kotlin/com/asap/bootstrap/web/image/api/ImageApi.kt
@@ -17,7 +17,7 @@ import org.springframework.web.multipart.MultipartFile
 interface ImageApi {
     @Operation(
         summary = "이미지 업로드",
-        description = "이미지를 업로드합니다.",
+        description = "이미지를 업로드합니다. 회원과 비회원 모두 이용 가능합니다.",
     )
     @PostMapping(consumes = ["multipart/form-data"])
     @ApiResponses(
@@ -28,8 +28,8 @@ interface ImageApi {
                 headers = [
                     Header(
                         name = "Authorization",
-                        description = "액세스 토큰",
-                        required = true,
+                        description = "액세스 토큰 (선택사항)",
+                        required = false,
                     ),
                 ],
             ),
@@ -41,6 +41,6 @@ interface ImageApi {
     )
     fun uploadImage(
         @RequestPart image: MultipartFile,
-        @AccessUser userId: String,
+        @AccessUser userId: String?,
     ): UploadImageResponse
 }

--- a/Bootstrap-Module/src/main/kotlin/com/asap/bootstrap/web/image/controller/ImageController.kt
+++ b/Bootstrap-Module/src/main/kotlin/com/asap/bootstrap/web/image/controller/ImageController.kt
@@ -14,7 +14,7 @@ class ImageController(
 ) : ImageApi {
     override fun uploadImage(
         image: MultipartFile,
-        userId: String,
+        userId: String?,
     ): UploadImageResponse {
         val response =
             uploadImageUsecase.upload(

--- a/Common-Module/src/main/kotlin/com/asap/common/security/SecurityContextHolder.kt
+++ b/Common-Module/src/main/kotlin/com/asap/common/security/SecurityContextHolder.kt
@@ -4,9 +4,7 @@ class SecurityContextHolder {
     companion object {
         private val contextHolder = ThreadLocal<SecurityContext<*, *>>()
 
-        fun getContext(): SecurityContext<*, *> {
-            return contextHolder.get()
-        }
+        fun getContext(): SecurityContext<*, *>? = contextHolder.get()
 
         fun setContext(context: SecurityContext<*, *>) {
             contextHolder.set(context)

--- a/Infrastructure-Module/AWS/src/main/kotlin/com/asap/aws/s3/S3ImageManagementAdapter.kt
+++ b/Infrastructure-Module/AWS/src/main/kotlin/com/asap/aws/s3/S3ImageManagementAdapter.kt
@@ -13,7 +13,9 @@ class S3ImageManagementAdapter(
     private val s3Template: S3Template,
 ) : ImageManagementPort {
     override fun save(image: ImageMetadata): UploadedImage {
-        val key = "${image.owner}/${UUID.randomUUID()}"
+        val owner = image.owner ?: ANONYMOUS_OWNER_ID
+
+        val key = "$owner/${UUID.randomUUID()}"
 
         val resource =
             s3Template.upload(
@@ -33,5 +35,6 @@ class S3ImageManagementAdapter(
 
     companion object {
         private const val BUCKET_NAME = "lettering-images"
+        private const val ANONYMOUS_OWNER_ID = "anonymous"
     }
 }


### PR DESCRIPTION
- `userId`를 nullable로 변경하여 비회원 이미지 업로드 지원.
- 비회원 업로드 시 기본 ID로 "anonymous" 설정.
- `ImageCommandServiceTest` 및 Controller 테스트에 관련 시나리오 추가.
- API 문서 변경: 액세스 토큰 필드를 선택사항으로 수정하고 설명 추가.