### PR TITLE
ASAP-457 회원가입 시 비회원 편지 코드 처리 로직 추가

### DIFF
--- a/Application-Module/src/main/kotlin/com/asap/application/letter/port/in/AddLetterUsecase.kt
+++ b/Application-Module/src/main/kotlin/com/asap/application/letter/port/in/AddLetterUsecase.kt
@@ -5,6 +5,8 @@ interface AddLetterUsecase {
 
     fun addPhysicalLetter(command: Command.AddPhysicalLetter)
 
+    fun addAnonymousLetter(command: Command.AddAnonymousLetter)
+
     sealed class Command {
         data class VerifyLetter(
             val letterId: String,
@@ -18,6 +20,11 @@ interface AddLetterUsecase {
             val templateType: Int,
             val userId: String,
             val draftId: String?,
+        ) : Command()
+
+        data class AddAnonymousLetter(
+            val letterCode: String,
+            val userId: String,
         ) : Command()
     }
 }

--- a/Application-Module/src/main/kotlin/com/asap/application/letter/service/LetterCommandService.kt
+++ b/Application-Module/src/main/kotlin/com/asap/application/letter/service/LetterCommandService.kt
@@ -152,6 +152,14 @@ class LetterCommandService(
         independentLetterManagementPort.save(independentLetter)
     }
 
+    override fun addAnonymousLetter(command: AddLetterUsecase.Command.AddAnonymousLetter) {
+        val sendLetter = sendLetterManagementPort.getLetterByCodeNotNull(command.letterCode)
+        val user = userManagementPort.getUserNotNull(DomainId(command.userId))
+
+        sendLetter.configSenderId(user.id)
+        sendLetterManagementPort.save(sendLetter)
+    }
+
     override fun moveToSpace(command: MoveLetterUsecase.Command.ToSpace) {
         independentLetterManagementPort.getIndependentLetterByIdNotNull(DomainId(command.letterId)).apply {
             val spaceLetter = SpaceLetter.createByIndependentLetter(this, DomainId(command.spaceId))

--- a/Application-Module/src/main/kotlin/com/asap/application/user/port/in/RegisterUserUsecase.kt
+++ b/Application-Module/src/main/kotlin/com/asap/application/user/port/in/RegisterUserUsecase.kt
@@ -3,9 +3,7 @@ package com.asap.application.user.port.`in`
 import java.time.LocalDate
 
 interface RegisterUserUsecase {
-
     fun registerUser(command: Command): Response
-
 
     data class Command(
         val registerToken: String,
@@ -13,11 +11,12 @@ interface RegisterUserUsecase {
         val privatePermission: Boolean,
         val marketingPermission: Boolean,
         val birthday: LocalDate?,
-        val realName: String
+        val realName: String,
     )
 
     data class Response(
         val accessToken: String,
-        val refreshToken: String
+        val refreshToken: String,
+        val userId: String,
     )
 }

--- a/Application-Module/src/test/kotlin/com/asap/application/letter/service/LetterCommandServiceTest.kt
+++ b/Application-Module/src/test/kotlin/com/asap/application/letter/service/LetterCommandServiceTest.kt
@@ -362,6 +362,40 @@ class LetterCommandServiceTest :
             }
         }
 
+
+        given("익명 편지를 사용자의 편지로 추가할 때") {
+            val letterCode = "letter-code"
+            val userId = "user-id"
+            val command = AddLetterUsecase.Command.AddAnonymousLetter(
+                letterCode = letterCode,
+                userId = userId,
+            )
+
+            // Create an anonymous letter using SendLetter.createAnonymous
+            val content = LetterContent(
+                content = "content",
+                templateType = 1,
+                images = mutableListOf("image1", "image2"),
+            )
+            val sendLetter = SendLetter.createAnonymous(
+                content = content,
+                receiverName = "receiverName",
+                letterCode = letterCode,
+            )
+
+            every { 
+                mockSendLetterManagementPort.getLetterByCodeNotNull(letterCode) 
+            } returns sendLetter
+
+            `when`("익명 편지를 사용자의 편지로 추가하면") {
+                letterCommandService.addAnonymousLetter(command)
+
+                then("편지의 발신자 ID가 설정되고 저장되어야 한다") {
+                    verify { mockSendLetterManagementPort.save(sendLetter) }
+                }
+            }
+        }
+
         given("보낸 편지 삭제 요청이 들어올 때") {
             val userId = "user-id"
             val sendLetters =

--- a/Bootstrap-Module/src/main/kotlin/com/asap/bootstrap/web/user/controller/UserController.kt
+++ b/Bootstrap-Module/src/main/kotlin/com/asap/bootstrap/web/user/controller/UserController.kt
@@ -1,5 +1,6 @@
 package com.asap.bootstrap.web.user.controller
 
+import com.asap.application.letter.port.`in`.AddLetterUsecase
 import com.asap.application.user.port.`in`.*
 import com.asap.bootstrap.web.user.api.UserApi
 import com.asap.bootstrap.web.user.dto.*
@@ -12,6 +13,7 @@ class UserController(
     private val deleteUserUsecase: DeleteUserUsecase,
     private val getUserInfoUsecase: GetUserInfoUsecase,
     private val updateUserUsecase: UpdateUserUsecase,
+    private val addLetterUsecase: AddLetterUsecase,
 ) : UserApi {
     override fun registerUser(request: RegisterUserRequest): RegisterUserResponse {
         val response =
@@ -25,6 +27,17 @@ class UserController(
                     request.realName,
                 ),
             )
+
+        // Handle anonymous letter code if it exists
+        request.anonymousSendLetterCode?.let { letterCode ->
+            addLetterUsecase.addAnonymousLetter(
+                AddLetterUsecase.Command.AddAnonymousLetter(
+                    letterCode = letterCode,
+                    userId = response.userId,
+                ),
+            )
+        }
+
         return RegisterUserResponse(response.accessToken, response.refreshToken)
     }
 

--- a/Bootstrap-Module/src/main/kotlin/com/asap/bootstrap/web/user/dto/RegisterUserRequest.kt
+++ b/Bootstrap-Module/src/main/kotlin/com/asap/bootstrap/web/user/dto/RegisterUserRequest.kt
@@ -16,6 +16,7 @@ data class RegisterUserRequest(
     @Schema(description = "생년 월일, yyyy-MM-dd, 값이 안넘어올 수 있음")
     val birthday: LocalDate?,
     @Schema(description = "실명")
-    val realName: String
-) {
-}
+    val realName: String,
+    @Schema(description = "비회원 상태로 전송한 편지의 코드")
+    val anonymousSendLetterCode: String?,
+)

--- a/Bootstrap-Module/src/test/kotlin/com/asap/bootstrap/acceptance/user/controller/UserControllerTest.kt
+++ b/Bootstrap-Module/src/test/kotlin/com/asap/bootstrap/acceptance/user/controller/UserControllerTest.kt
@@ -40,7 +40,7 @@ class UserControllerTest : AcceptanceSupporter() {
     @Test
     fun registerUserTest() {
         // given
-        val request = RegisterUserRequest("register", true, true, true, LocalDate.now(), "realName")
+        val request = RegisterUserRequest("register", true, true, true, LocalDate.now(), "realName", null)
         val command =
             RegisterUserUsecase.Command(
                 request.registerToken,
@@ -53,8 +53,9 @@ class UserControllerTest : AcceptanceSupporter() {
         given(registerUserUsecase.registerUser(command)).willReturn(
             RegisterUserUsecase.Response(
                 "accessToken",
-                "refreshToken"
-            )
+                "refreshToken",
+                "userId",
+            ),
         )
         // when
         val response =

--- a/Domain-Module/src/main/kotlin/com/asap/domain/letter/entity/SendLetter.kt
+++ b/Domain-Module/src/main/kotlin/com/asap/domain/letter/entity/SendLetter.kt
@@ -12,7 +12,7 @@ import java.time.LocalDateTime
 class SendLetter(
     id: DomainId,
     val content: LetterContent,
-    val senderId: DomainId? = null,
+    var senderId: DomainId?,
     var receiverName: String,
     var letterCode: String?,
     var status: LetterStatus,
@@ -88,6 +88,14 @@ class SendLetter(
         this.receiverName = ""
         this.letterCode = null
         this.receiverId = null
+        updateTime()
+    }
+
+    fun configSenderId(senderId: DomainId) {
+        check(this.senderId == null) {
+            "SenderId is already set"
+        }
+        this.senderId = senderId
         updateTime()
     }
 }


### PR DESCRIPTION
- `UserController.registerUser`에 비회원 편지 코드 처리 로직 추가: `addAnonymousLetter` 메서드를 호출하여 편지와 유저를 연결.
- `RegisterUserRequest` DTO에 `anonymousSendLetterCode` 필드 추가.
- `AddLetterUsecase`에 익명 편지를 사용자의 편지로 추가하는 `addAnonymousLetter` 메서드 및 관련 커맨드 추가.
- `SendLetter` 엔터티에 `configSendId` 메서드 추가: 발신자 ID 설정 및 검증.
- 관련 테스트 코드 추가 및 업데이트: 비회원 코드 처리 케이스 통합 테스트 포함.