### PR TITLE
ASAP-458 LetterShareStatus API userId nullable 처리

### DIFF
--- a/Bootstrap-Module/src/main/kotlin/com/asap/bootstrap/web/letter/api/LetterLogApi.kt
+++ b/Bootstrap-Module/src/main/kotlin/com/asap/bootstrap/web/letter/api/LetterLogApi.kt
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RequestParam
 @Tag(name = "Letter", description = "Letter API")
 @RequestMapping("/api/v1/letters/logs")
 interface LetterLogApi {
-
     @Operation(summary = "편지 공유 상태 조회")
     @GetMapping("/share/status")
     @ApiResponses(
@@ -41,14 +40,14 @@ interface LetterLogApi {
                 content = [
                     Content(
                         mediaType = "application/json",
-                        schema = Schema(implementation = LetterShareStatusResponse::class)
-                    )
-                ]
-            )
-        ]
+                        schema = Schema(implementation = LetterShareStatusResponse::class),
+                    ),
+                ],
+            ),
+        ],
     )
     fun getLetterShareStatus(
         @RequestParam("letterCode") letterCode: String,
-        @AccessUser userId: String
+        @AccessUser userId: String?,
     ): LetterShareStatusResponse
 }

--- a/Bootstrap-Module/src/main/kotlin/com/asap/bootstrap/web/letter/controller/LetterLogController.kt
+++ b/Bootstrap-Module/src/main/kotlin/com/asap/bootstrap/web/letter/controller/LetterLogController.kt
@@ -10,18 +10,20 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class LetterLogController(
     private val letterLogUsecase: LetterLogUsecase,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
 ) : LetterLogApi {
-    override fun getLetterShareStatus(letterCode: String, userId: String): LetterShareStatusResponse {
-        return letterLogUsecase.finLatestLogByLetterCode(letterCode)?.let {
-            val kakaoWebHookRequest =
-                objectMapper.readValue(it.logContent, KakaoWebHookRequest::class.java)
+    override fun getLetterShareStatus(
+        letterCode: String,
+        userId: String?,
+    ): LetterShareStatusResponse =
+        letterLogUsecase.finLatestLogByLetterCode(letterCode)?.let {
+            val kakaoWebHookRequest = objectMapper.readValue(it.logContent, KakaoWebHookRequest::class.java)
+
             LetterShareStatusResponse.success(
                 letterId = it.letterId,
-                shareTarget = kakaoWebHookRequest.chatType
+                shareTarget = kakaoWebHookRequest.chatType,
             )
         } ?: run {
             LetterShareStatusResponse.fail()
         }
-    }
 }


### PR DESCRIPTION
- `LetterLogApi.getLetterShareStatus` 메서드의 파라미터 `userId`를 nullable로 수정.
- `LetterLogController`의 관련 로직 변경: nullable `userId` 지원.
- API 문서 스키마 공백 및 포맷 관련 경미한 수정.